### PR TITLE
Update Project and CIs to Julia 1.4

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,9 +1,7 @@
 environment:
   matrix:
-  - julia_version: 1
-  - julia_version: 1.1
-  - julia_version: 1.2
   - julia_version: 1.3
+  - julia_version: 1.4
   - julia_version: nightly
 
 platform:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,10 +4,8 @@ task:
   name: FreeBSD
   env:
     matrix:
-      - JULIA_VERSION: 1.0
-      - JULIA_VERSION: 1.1
-      - JULIA_VERSION: 1.2
       - JULIA_VERSION: 1.3
+      - JULIA_VERSION: 1.4
       - JULIA_VERSION: nightly
   install_script:
     - sh -c "$(fetch https://raw.githubusercontent.com/ararslan/CirrusCI.jl/master/bin/install.sh -o -)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,8 @@ os:
   - windows
 
 julia:
-  - 1.0
-  - 1.1
-  - 1.2
   - 1.3
+  - 1.4
   - nightly
 
 matrix:
@@ -28,5 +26,6 @@ branches:
     - /^v\d+\.\d+(\.\d+)?(-\S*)?$/ # tags
 
 after_success:
-  - julia -e 'using Pkg; cd(Pkg.dir("QuadraticModels")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
-  - julia -e 'using Pkg; cd(Pkg.dir("QuadraticModels")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+  - julia -e 'if Sys.islinux() && string(VERSION)[1:3] ==  "1.4"
+      using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder()); Codecov.submit(Codecov.process_folder())
+    end'

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
-authors = ["Dominique Orban <dominique.orban@gmail.com>"]
 name = "QuadraticModels"
 uuid = "f468eda6-eac5-11e8-05a5-ff9e497bcd19"
+authors = ["Dominique Orban <dominique.orban@gmail.com>"]
 version = "0.1.0"
 
 [deps]
@@ -8,14 +8,19 @@ FastClosures = "9aa1b823-49e4-5ca5-8b0f-3971ec8bab6a"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LinearOperators = "5c8ed15e-5a4c-59e4-a42b-c7e8811fb125"
 NLPModels = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
-Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 FastClosures = "0.2.1, 0.3.0"
 LinearOperators = "0.7.0, 1"
-NLPModels = "0.10.0, 1"
+NLPModels = "0.12"
 Requires = "0.3, 0.4, 0.5"
 julia = "^1.0.0"
+
+[extras]
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Printf","Test"]


### PR DESCRIPTION
I'm removing support for NLPModels < 1.2 because I'm updating to support 1.2 and this package it not released yet.