### PR TITLE
Change the QuadraticModel Matrix constructor, add more tests

### DIFF
--- a/src/qpmodel.jl
+++ b/src/qpmodel.jl
@@ -56,8 +56,7 @@ function QuadraticModel(c :: AbstractVector{T}, H :: SparseMatrixCSC{T, Int};
                         c0 :: T = zero(T), kwargs...) where T
   ncon, nvar = size(A)
   tril!(H)
-  nnzh, Hrows, Hcols, Hvals =
-    nnz(H), findnz(H)...
+  nnzh, Hrows, Hcols, Hvals = nnz(H), findnz(H)...
   nnzj, Arows, Acols, Avals = if ncon == 0
     0, Int[], Int[], T[]
   elseif issparse(A)

--- a/src/qpmodel.jl
+++ b/src/qpmodel.jl
@@ -49,18 +49,15 @@ function QuadraticModel(c :: AbstractVector{T},
                  QPData(c0, c, Hrows, Hcols, Hvals, Arows, Acols, Avals))
 end
 
-function QuadraticModel(c :: AbstractVector{T}, H :: Symmetric{T,<:AbstractMatrix};
+function QuadraticModel(c :: AbstractVector{T}, H :: SparseMatrixCSC{T, Int};
                         A :: AbstractMatrix = zeros(T, 0, length(c)),
                         lcon :: AbstractVector = zeros(T, 0), ucon :: AbstractVector = zeros(T, 0),
                         lvar :: AbstractVector = fill(T(-Inf), length(c)), uvar :: AbstractVector = fill(T(Inf), length(c)),
                         c0 :: T = zero(T), kwargs...) where T
   ncon, nvar = size(A)
+  tril!(H)
   nnzh, Hrows, Hcols, Hvals =
-    nnz(H.data), findnz(H.data)...
-  # else
-  #   I = ((i,j,H[i,j]) for i = 1:nvar, j = 1:nvar if i ≥ j)
-  #   div(nvar * (nvar + 1), 2), getindex.(I, 1), getindex.(I, 2), getindex.(I, 3)
-  # end
+    nnz(H), findnz(H)...
   nnzj, Arows, Acols, Avals = if ncon == 0
     0, Int[], Int[], T[]
   elseif issparse(A)
@@ -76,6 +73,8 @@ function QuadraticModel(c :: AbstractVector{T}, H :: Symmetric{T,<:AbstractMatri
                  Counters(),
                  QPData(c0, c, Hrows, Hcols, Hvals, Arows, Acols, Avals))
 end
+
+QuadraticModel(c :: AbstractVector{T}, H :: AbstractMatrix; args...) where T = QuadraticModel(c, sparse(H); args...)
 
 """
     QuadraticModel(nlp, x)
@@ -102,11 +101,6 @@ function QuadraticModel(model :: AbstractNLPModel, x :: AbstractVector; kwargs..
   end
 end
 
-QuadraticModel(c :: AbstractVector{T}, H :: SparseMatrixCSC{T,Int};
-                        args...) where T = QuadraticModel(c, Symmetric(H, :L); args...)
-QuadraticModel(c :: AbstractVector{T}, H ::AbstractMatrix;
-                        args...) where T = QuadraticModel(c, sparse(H); args...)
-                        
 linobj(qp::AbstractQuadraticModel, args...) = qp.data.c
 
 function NLPModels.objgrad!(qp :: AbstractQuadraticModel, x :: AbstractVector, g :: AbstractVector)

--- a/src/qpmodel.jl
+++ b/src/qpmodel.jl
@@ -49,18 +49,18 @@ function QuadraticModel(c :: AbstractVector{T},
                  QPData(c0, c, Hrows, Hcols, Hvals, Arows, Acols, Avals))
 end
 
-function QuadraticModel(c :: AbstractVector{T}, H :: AbstractMatrix;
+function QuadraticModel(c :: AbstractVector{T}, H :: Symmetric{T,<:AbstractMatrix};
                         A :: AbstractMatrix = zeros(T, 0, length(c)),
                         lcon :: AbstractVector = zeros(T, 0), ucon :: AbstractVector = zeros(T, 0),
                         lvar :: AbstractVector = fill(T(-Inf), length(c)), uvar :: AbstractVector = fill(T(Inf), length(c)),
                         c0 :: T = zero(T), kwargs...) where T
   ncon, nvar = size(A)
-  nnzh, Hrows, Hcols, Hvals = if issparse(H)
-    nnz(tril(H)), findnz(tril(H))...
-  else
-    I = ((i,j,H[i,j]) for i = 1:nvar, j = 1:nvar if i ≥ j)
-    div(nvar * (nvar + 1), 2), getindex.(I, 1), getindex.(I, 2), getindex.(I, 3)
-  end
+  nnzh, Hrows, Hcols, Hvals =
+    nnz(H.data), findnz(H.data)...
+  # else
+  #   I = ((i,j,H[i,j]) for i = 1:nvar, j = 1:nvar if i ≥ j)
+  #   div(nvar * (nvar + 1), 2), getindex.(I, 1), getindex.(I, 2), getindex.(I, 3)
+  # end
   nnzj, Arows, Acols, Avals = if ncon == 0
     0, Int[], Int[], T[]
   elseif issparse(A)
@@ -102,6 +102,11 @@ function QuadraticModel(model :: AbstractNLPModel, x :: AbstractVector; kwargs..
   end
 end
 
+QuadraticModel(c :: AbstractVector{T}, H :: SparseMatrixCSC{T,Int};
+                        args...) where T = QuadraticModel(c, Symmetric(H, :L); args...)
+QuadraticModel(c :: AbstractVector{T}, H ::AbstractMatrix;
+                        args...) where T = QuadraticModel(c, sparse(H); args...)
+                        
 linobj(qp::AbstractQuadraticModel, args...) = qp.data.c
 
 function NLPModels.objgrad!(qp :: AbstractQuadraticModel, x :: AbstractVector, g :: AbstractVector)

--- a/test/problems/bndqp.jl
+++ b/test/problems/bndqp.jl
@@ -9,9 +9,29 @@ function bndqp_autodiff()
   return ADNLPModel(f, x0, lvar, uvar, name="bndqp_autodiff")
 end
 
-function bndqp_QP()
+function bndqp_QP_dense()
   c    = [1.0; 1.0]
-  H    = [-2.0 0.0; 3.0 4.0]
+  H    = [-2.0 3.0; 3.0 4.0]
+  uvar = [1.0; 1.0]
+  lvar = [0.0; 0.0]
+  x0   = [0.5; 0.5]
+
+  return QuadraticModel(c, H, lvar=lvar, uvar=uvar, x0=x0, name="bndqp_QP")
+end
+
+function bndqp_QP_sparse()
+  c    = [1.0; 1.0]
+  H    = sparse([-2.0 0.0; 3.0 4.0])
+  uvar = [1.0; 1.0]
+  lvar = [0.0; 0.0]
+  x0   = [0.5; 0.5]
+
+  return QuadraticModel(c, H, lvar=lvar, uvar=uvar, x0=x0, name="bndqp_QP")
+end
+
+function bndqp_QP_symmetric()
+  c    = [1.0; 1.0]
+  H    = Symmetric([-2.0 0.0; 3.0 4.0], :L)
   uvar = [1.0; 1.0]
   lvar = [0.0; 0.0]
   x0   = [0.5; 0.5]

--- a/test/problems/eqconqp.jl
+++ b/test/problems/eqconqp.jl
@@ -11,10 +11,32 @@ function eqconqp_autodiff()
   return ADNLPModel(f, x0, c, lcon, ucon, name="eqconqp_autodiff")
 end
 
-function eqconqp_QP()
+function eqconqp_QP_dense()
+  n    = 50
+  c    = zeros(n)
+  H    = Matrix(spdiagm(0 => 1.0:n))
+  A    = ones(1, n)
+  lcon = [1.0]
+  ucon = [1.0]
+
+  return QuadraticModel(c, H, A=A, lcon=lcon, ucon=ucon, name="eqconqp_QP")
+end
+
+function eqconqp_QP_sparse()
   n    = 50
   c    = zeros(n)
   H    = spdiagm(0 => 1.0:n)
+  A    = ones(1, n)
+  lcon = [1.0]
+  ucon = [1.0]
+
+  return QuadraticModel(c, H, A=A, lcon=lcon, ucon=ucon, name="eqconqp_QP")
+end
+
+function eqconqp_QP_symmetric()
+  n    = 50
+  c    = zeros(n)
+  H    = Symmetric(spdiagm(0 => 1.0:n), :L)
   A    = ones(1, n)
   lcon = [1.0]
   ucon = [1.0]

--- a/test/problems/eqconqp.jl
+++ b/test/problems/eqconqp.jl
@@ -3,7 +3,7 @@ function eqconqp_autodiff()
 
   n    = 50
   x0   = zeros(n)
-  f(x) = sum(i * x[i]^2 for i = 1:n) / 2
+  f(x) = sum(i * x[i]^2 for i = 1:n) / 2 + x[1] * x[n]
   c(x) = [sum(x) - 1.0]
   lcon = [0.0]
   ucon = [0.0]
@@ -14,7 +14,8 @@ end
 function eqconqp_QP_dense()
   n    = 50
   c    = zeros(n)
-  H    = Matrix(spdiagm(0 => 1.0:n))
+  H    = diagm(0 => 1.0:n)
+  H[n, 1] = 1.0
   A    = ones(1, n)
   lcon = [1.0]
   ucon = [1.0]
@@ -26,6 +27,7 @@ function eqconqp_QP_sparse()
   n    = 50
   c    = zeros(n)
   H    = spdiagm(0 => 1.0:n)
+  H[n, 1] = 1.0
   A    = ones(1, n)
   lcon = [1.0]
   ucon = [1.0]
@@ -36,7 +38,9 @@ end
 function eqconqp_QP_symmetric()
   n    = 50
   c    = zeros(n)
-  H    = Symmetric(spdiagm(0 => 1.0:n), :L)
+  H    = spdiagm(0 => 1.0:n)
+  H[n, 1] = 1.0
+  H    = Symmetric(H, :L)
   A    = ones(1, n)
   lcon = [1.0]
   ucon = [1.0]
@@ -48,6 +52,7 @@ function eqconqp_QPSData()
   n    = 50
   c    = zeros(n)
   H    = spdiagm(0 => 1.0:n)
+  H[n, 1] = 1.0
   A    = ones(1, n)
   lcon = [1.0]
   ucon = [1.0]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,7 +10,7 @@ nlpmodels_problems_path = joinpath(nlpmodels_path, "problems")
 # Definition of quadratic problems
 qp_problems_Matrix = ["bndqp", "eqconqp"]
 qp_problems_COO = ["uncqp", "ineqconqp"]
-for qp in vcat(qp_problems_Matrix, qp_problems_COO)
+for qp in [qp_problems_Matrix; qp_problems_COO]
   include(joinpath("problems", "$qp.jl"))
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,8 +8,9 @@ nlpmodels_path = joinpath(dirname(pathof(NLPModels)), "..", "test")
 nlpmodels_problems_path = joinpath(nlpmodels_path, "problems")
 
 # Definition of quadratic problems
-qp_problems = ["uncqp", "bndqp", "eqconqp", "ineqconqp"]
-for qp in qp_problems
+qp_problems_Matrix = ["bndqp", "eqconqp"]
+qp_problems_COO = ["uncqp", "ineqconqp"]
+for qp in vcat(qp_problems_Matrix, qp_problems_COO)
   include(joinpath("problems", "$qp.jl"))
 end
 

--- a/test/test_consistency.jl
+++ b/test/test_consistency.jl
@@ -30,7 +30,19 @@ function check_quadratic_model(model, quadraticmodel)
   reset!(quadraticmodel)
 end
 
-for problem in qp_problems
+for problem in qp_problems_Matrix
+  @info "Checking consistency of problem $problem"
+  nlp_ad = eval(Symbol(problem * "_autodiff"))()
+  nlp_qps = eval(Symbol(problem * "_QPSData"))()
+  nlp_qm_dense = eval(Symbol(problem * "_QP_dense"))()
+  nlp_qm_sparse = eval(Symbol(problem * "_QP_sparse"))()
+  nlp_qm_symmetric = eval(Symbol(problem * "_QP_symmetric"))()
+  nlps = [nlp_ad, nlp_qm_dense, nlp_qm_sparse, nlp_qm_symmetric, nlp_qps]
+  consistent_nlps(nlps)
+  @info "  Consistency checks ✓"
+end
+
+for problem in qp_problems_COO
   @info "Checking consistency of problem $problem"
   nlp_ad = eval(Symbol(problem * "_autodiff"))()
   nlp_qm = eval(Symbol(problem * "_QP"))()


### PR DESCRIPTION
I finally changed the type of `H` in the default constructor to `SparseMatrixCSC{T, Int}`. I think the `tril!` function is mandatory because if the user inputs a `Symmetric{T, SparseMatrixCSC{I, Int}}` matrix, it is not possible to know if this matrix was constructed with a lower triangular matrix (maybe I am mistaken).