### PR TITLE
SlackModel for QuadraticModels

### DIFF
--- a/src/QuadraticModels.jl
+++ b/src/QuadraticModels.jl
@@ -13,7 +13,8 @@ import NLPModels:
     objgrad, objgrad!, obj, grad, grad!,
     hess_coord, hess, hess_op, hprod,
     cons, cons!,
-    jac_coord, jac, jac_op, jprod, jtprod
+    jac_coord, jac, jac_op, jprod, jtprod,
+    SlackModel, slack_meta
 
 export QuadraticModel
 

--- a/src/qpmodel.jl
+++ b/src/qpmodel.jl
@@ -188,10 +188,12 @@ function SlackModel!(qp :: AbstractQuadraticModel)
   nfix = length(qp.meta.jfix)
   ns = qp.meta.ncon - nfix
   T = eltype(qp.data.c)
-  qp.data.Arows = [qp.data.Arows; qp.meta.jlow; qp.meta.jupp; qp.meta.jrng]
-  qp.data.Acols = [qp.data.Acols; qp.meta.nvar+1:qp.meta.nvar+ns]
-  qp.data.Avals = [qp.data.Avals; .-ones(T, ns)]
-  qp.data.c = [qp.data.c; zeros(T, ns)]
+  append!(qp.data.Arows, qp.meta.jlow)
+  append!(qp.data.Arows, qp.meta.jupp)
+  append!(qp.data.Arows, qp.meta.jrng)
+  append!(qp.data.Acols, qp.meta.nvar+1:qp.meta.nvar+ns)
+  append!(qp.data.Avals, .-ones(T, ns))
+  append!(qp.data.c, zeros(T, ns))
 
   qp.meta = NLPModels.slack_meta(qp.meta, name=qp.meta.name)
   return qp

--- a/src/qpmodel.jl
+++ b/src/qpmodel.jl
@@ -181,3 +181,19 @@ function NLPModels.jtprod!(qp :: AbstractQuadraticModel, x :: AbstractVector, v 
   coo_prod!(qp.data.Acols, qp.data.Arows, qp.data.Avals, v, Atv)
   return Atv
 end
+
+function NLPModels.SlackModel(qp :: AbstractQuadraticModel, name=qp.meta.name * "-slack")
+  qp.meta.ncon == length(qp.meta.jfix) && return qp
+  
+  nfix = length(qp.meta.jfix)
+  ns = qp.meta.ncon - nfix
+  T = eltype(qp.data.c)
+  qp.data.Arows = [qp.data.Arows; qp.meta.jlow; qp.meta.jupp; qp.meta.jrng]
+  qp.data.Acols = [qp.data.Acols; qp.meta.nvar+1:qp.meta.nvar+ns]
+  qp.data.Avals = [qp.data.Avals; .-ones(T, ns)]
+  qp.data.c = [qp.data.c; zeros(T, ns)]
+
+  meta = NLPModels.slack_meta(qp.meta, name=name)
+  qp.meta = meta
+  return qp
+end

--- a/src/qpmodel.jl
+++ b/src/qpmodel.jl
@@ -192,8 +192,8 @@ function SlackModel!(qp :: AbstractQuadraticModel)
   append!(qp.data.Arows, qp.meta.jupp)
   append!(qp.data.Arows, qp.meta.jrng)
   append!(qp.data.Acols, qp.meta.nvar+1:qp.meta.nvar+ns)
-  append!(qp.data.Avals, .-ones(T, ns))
-  append!(qp.data.c, zeros(T, ns))
+  append!(qp.data.Avals, (-one(T) for _ = 1 : ns))
+  append!(qp.data.c, (zero(T) for _ = 1 : ns))
 
   qp.meta = NLPModels.slack_meta(qp.meta, name=qp.meta.name)
   return qp

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,3 +16,42 @@ end
 
 include(joinpath(nlpmodels_path, "consistency.jl"))
 include("test_consistency.jl")
+
+function testSM(sm) # test function for a specific problem
+  @test (sm.meta.ncon == 2 && sm.meta.nvar == 5)
+  @test sm.meta.lcon == sm.meta.ucon
+  lvar_sm_true = [0.; 0.; 0.; -4.0; -3.0]
+  uvar_sm_true = [Inf; Inf; Inf; Inf; -2.0]
+  H_sm_true = sparse([6. 0. 0. 0. 0.
+                      2. 5. 0. 0. 0.
+                      1. 2. 4. 0. 0.
+                      0. 0. 0. 0. 0.
+                      0. 0. 0. 0. 0.])
+  A_sm_true = sparse([1.  0.  1.  0.  -1.
+                      0.  2.  1.  -1.  0.])
+
+  @test all(lvar_sm_true .== sm.meta.lvar)
+  @test all(uvar_sm_true .== sm.meta.uvar)
+  @test all(sparse(sm.data.Arows, sm.data.Acols, sm.data.Avals, 2, 5) .== A_sm_true)
+  @test all(sparse(sm.data.Hrows, sm.data.Hcols, sm.data.Hvals, 5, 5) .== H_sm_true)
+end
+  
+
+@testset "SlackModel" begin
+  H = [6. 2. 1.
+       2. 5. 2.
+       1. 2. 4.]
+  c = [-8.; -3; -3]
+  A = [1. 0. 1.
+       0. 2. 1.]
+  b = [0.; 3]
+  l = [0.;0;0]
+  u = [Inf; Inf; Inf]
+  T = eltype(c)
+  qp = QuadraticModel(c, H, A=A, lcon=[-3; -4], ucon=[-2.; Inf], lvar=l, uvar=u, c0=0., name="QM1")
+  sm = SlackModel(qp)
+  testSM(sm)
+  
+  SlackModel!(qp)
+  testSM(qp)
+end


### PR DESCRIPTION
This allows to get H and A faster after using SlackModel. 
I modified qp.data, and created another meta using the code already written in NLPModels.slack_meta.