### PR TITLE
Presolve fixed variables

### DIFF
--- a/src/QuadraticModels.jl
+++ b/src/QuadraticModels.jl
@@ -29,9 +29,10 @@ import NLPModels:
   SlackModel,
   slack_meta
 
-export QuadraticModel
+export QuadraticModel, presolve, postsolve!
 
 include("qpmodel.jl")
+include("presolve/presolve.jl")
 
 function __init__()
   @require QPSReader = "10f199a5-22af-520b-b891-7ce84a7b1bd0" include("qps.jl")

--- a/src/QuadraticModels.jl
+++ b/src/QuadraticModels.jl
@@ -29,7 +29,7 @@ import NLPModels:
   SlackModel,
   slack_meta
 
-export QuadraticModel, presolve, postsolve!
+export AbstractQuadraticModel, QuadraticModel, presolve, postsolve!
 
 include("qpmodel.jl")
 include("presolve/presolve.jl")

--- a/src/presolve/presolve.jl
+++ b/src/presolve/presolve.jl
@@ -82,6 +82,7 @@ function presolve(qm::QuadraticModel{T, S}; kwargs...) where {T <: Real, S}
     lin = 1:ncon,
     nln = Int[],
     islp = (ncon == 0);
+    minimize = qm.meta.minimize,
     kwargs...,
   )
   ps = PresolvedQuadraticModel(psmeta, Counters(), psdata, xrm)
@@ -99,5 +100,7 @@ Retrieve the solution `x_out` of the original QP `qm` given the solution of the 
 function postsolve!(qm::QuadraticModel{T, S}, psqm::PresolvedQuadraticModel{T, S}, x_in::S, x_out::S) where {T, S}
   if length(qm.meta.ifix) > 0
     restore_ifix!(qm.meta.ifix, psqm.xrm, x_in, x_out)
+  else
+    x_out .= @views x_in[1: qm.meta.nvar]
   end
 end

--- a/src/presolve/presolve.jl
+++ b/src/presolve/presolve.jl
@@ -1,0 +1,87 @@
+include("remove_ifix.jl")
+
+mutable struct PresolvedQuadraticModel{T <: Real, S} <: AbstractQuadraticModel{T, S}
+  meta::NLPModelMeta{T, S}
+  counters::Counters
+  data::QPData{T, S}
+  xrm::S
+end
+
+function copy_data(data::QPData, meta::NLPModelMeta)
+  psdata = QPData(
+    copy(data.c0),
+    copy(data.c),
+    copy(data.Hrows),
+    copy(data.Hcols),
+    copy(data.Hvals),
+    copy(data.Arows),
+    copy(data.Acols),
+    copy(data.Avals),
+  )
+  lcon, ucon = copy(meta.lcon), copy(meta.ucon)
+  lvar, uvar = copy(meta.lvar), copy(meta.uvar)
+  nvar, ncon = copy(meta.nvar), copy(meta.ncon)
+
+  return psdata, lcon, ucon, lvar, uvar, nvar, ncon 
+end
+
+function presolve(qm::QuadraticModel{T, S}; kwargs...) where {T <: Real, S}
+
+  psdata, lcon, ucon, lvar, uvar, nvar, ncon = copy_data(qm.data, qm.meta)
+
+  ifix = qm.meta.ifix
+  if length(ifix) > 0
+    xrm, psdata.c0, nvarps = remove_ifix!(
+      ifix,
+      psdata.Hrows,
+      psdata.Hcols,
+      psdata.Hvals,
+      nvar,
+      psdata.Arows,
+      psdata.Acols,
+      psdata.Avals,
+      psdata.c,
+      psdata.c0,
+      lvar,
+      uvar,
+      lcon,
+      ucon,
+    )
+  else
+    nvarps = nvar
+    xrm = S(undef, 0)
+  end
+
+  # form meta
+  nnzh = length(psdata.Hvals)
+  if !(nnzh == length(psdata.Hrows) == length(psdata.Hcols))
+    error("The length of Hrows, Hcols and Hvals must be the same")
+  end
+  nnzj = length(psdata.Avals)
+  if !(nnzj == length(psdata.Arows) == length(psdata.Acols))
+    error("The length of Arows, Acols and Avals must be the same")
+  end
+  psmeta = NLPModelMeta(
+    nvarps,
+    lvar = lvar,
+    uvar = uvar,
+    ncon = ncon,
+    lcon = lcon,
+    ucon = ucon,
+    nnzj = nnzj,
+    nnzh = nnzh,
+    lin = 1:ncon,
+    nln = Int[],
+    islp = (ncon == 0);
+    kwargs...,
+  )
+  ps = PresolvedQuadraticModel(psmeta, Counters(), psdata, xrm)
+
+  return ps
+end
+
+function postsolve!(qm::QuadraticModel{T, S}, psqm::PresolvedQuadraticModel{T, S}, x_in::S, x_out::S) where {T, S}
+  if length(id.ifix) > 0
+    restore_ifix!(qm.meta.ifix, psqm.xrm, x_in, x_out)
+  end
+end

--- a/src/presolve/presolve.jl
+++ b/src/presolve/presolve.jl
@@ -70,7 +70,7 @@ function presolve(qm::QuadraticModel{T, S}; kwargs...) where {T <: Real, S}
   if !(nnzj == length(psdata.Arows) == length(psdata.Acols))
     error("The length of Arows, Acols and Avals must be the same")
   end
-  psmeta = NLPModelMeta(
+  psmeta = NLPModelMeta{T, S}(
     nvarps,
     lvar = lvar,
     uvar = uvar,

--- a/src/presolve/presolve.jl
+++ b/src/presolve/presolve.jl
@@ -1,6 +1,6 @@
 include("remove_ifix.jl")
 
-mutable struct PresolvedQuadraticModel{T <: Real, S} <: AbstractQuadraticModel{T, S}
+mutable struct PresolvedQuadraticModel{T, S} <: AbstractQuadraticModel{T, S}
   meta::NLPModelMeta{T, S}
   counters::Counters
   data::QPData{T, S}
@@ -25,6 +25,15 @@ function copy_data(data::QPData, meta::NLPModelMeta)
   return psdata, lcon, ucon, lvar, uvar, nvar, ncon 
 end
 
+"""
+    psqm = presolve(qm::QuadraticModel{T, S}; kwargs...)
+
+Apply a presolve routine to `qm` and returns a `PresolvedQuadraticModel{T, S} <: AbstractQuadraticModel{T, S}`.
+The presolve operations currently implemented are:
+
+- [`remove_ifix!`](@ref)
+
+"""
 function presolve(qm::QuadraticModel{T, S}; kwargs...) where {T <: Real, S}
 
   psdata, lcon, ucon, lvar, uvar, nvar, ncon = copy_data(qm.data, qm.meta)
@@ -80,8 +89,15 @@ function presolve(qm::QuadraticModel{T, S}; kwargs...) where {T <: Real, S}
   return ps
 end
 
+"""
+    postsolve!(qm::QuadraticModel{T, S}, psqm::PresolvedQuadraticModel{T, S}, 
+               x_in::S, x_out::S) where {T, S}
+
+Retrieve the solution `x_out` of the original QP `qm` given the solution of the presolved QP (`psqm`)
+`x_in`.
+"""
 function postsolve!(qm::QuadraticModel{T, S}, psqm::PresolvedQuadraticModel{T, S}, x_in::S, x_out::S) where {T, S}
-  if length(id.ifix) > 0
+  if length(qm.meta.ifix) > 0
     restore_ifix!(qm.meta.ifix, psqm.xrm, x_in, x_out)
   end
 end

--- a/src/presolve/presolve.jl
+++ b/src/presolve/presolve.jl
@@ -7,24 +7,6 @@ mutable struct PresolvedQuadraticModel{T, S} <: AbstractQuadraticModel{T, S}
   xrm::S
 end
 
-function copy_data(data::QPData, meta::NLPModelMeta)
-  psdata = QPData(
-    copy(data.c0),
-    copy(data.c),
-    copy(data.Hrows),
-    copy(data.Hcols),
-    copy(data.Hvals),
-    copy(data.Arows),
-    copy(data.Acols),
-    copy(data.Avals),
-  )
-  lcon, ucon = copy(meta.lcon), copy(meta.ucon)
-  lvar, uvar = copy(meta.lvar), copy(meta.uvar)
-  nvar, ncon = copy(meta.nvar), copy(meta.ncon)
-
-  return psdata, lcon, ucon, lvar, uvar, nvar, ncon 
-end
-
 """
     psqm = presolve(qm::QuadraticModel{T, S}; kwargs...)
 
@@ -36,7 +18,11 @@ The presolve operations currently implemented are:
 """
 function presolve(qm::QuadraticModel{T, S}; kwargs...) where {T <: Real, S}
 
-  psdata, lcon, ucon, lvar, uvar, nvar, ncon = copy_data(qm.data, qm.meta)
+  psqm = deepcopy(qm)
+  psdata = psqm.data
+  lvar, uvar = psqm.meta.lvar, psqm.meta.uvar
+  lcon, ucon = psqm.meta.lcon, psqm.meta.ucon
+  nvar, ncon = psqm.meta.nvar, psqm.meta.ncon
 
   ifix = qm.meta.ifix
   if length(ifix) > 0

--- a/src/presolve/remove_ifix.jl
+++ b/src/presolve/remove_ifix.jl
@@ -1,0 +1,136 @@
+# ̃xᵀ̃Hx̃ + ̃ĉᵀx̃ + lⱼ²Hⱼⱼ + cⱼxⱼ + c₀
+# ̂c = ̃c + 2lⱼΣₖHⱼₖxₖ , k ≂̸ j  
+function remove_ifix!(
+  ifix,
+  Hrows,
+  Hcols,
+  Hvals,
+  nvar,
+  Arows,
+  Acols,
+  Avals,
+  c::AbstractVector{T},
+  c0,
+  lvar,
+  uvar,
+  lcon,
+  ucon,
+) where {T}
+  
+  # assume Hcols is sorted
+  c0_offset = zero(T)
+  Hnnz = length(Hrows)
+  Hrm = 0
+  Annz = length(Arows)
+  Arm = 0
+  # assume ifix is sorted and length(ifix) > 0
+  nfix = length(ifix)
+
+  # remove ifix 1 by 1 in H and A and update QP data
+  for idxfix = 1:nfix
+    currentifix = ifix[idxfix]
+    xifix = lvar[currentifix]
+    newcurrentifix = currentifix - idxfix + 1
+
+    Hwritepos = 1
+    shiftHj = 1 # increase Hj of currentj - 1 if Hj
+    if Hnnz > 0
+      oldHj = Hrows[1]
+    end
+    # remove ifix in H and update data
+    k = 1
+    while k <= Hnnz && Hcols[k] <= (nvar - idxfix + 1)
+      Hi, Hj, Hx = Hrows[k], Hcols[k], Hvals[k] # Hj sorted 
+  
+      while (Hj == oldHj) && shiftHj <= idxfix - 1 && Hj + shiftHj - 1 >= ifix[shiftHj]
+        shiftHj += 1
+      end
+      shiftHi = 1
+      while shiftHi <= idxfix - 1 && Hi + shiftHi - 1 >= ifix[shiftHi]
+        shiftHi += 1
+      end
+      if Hi == Hj == newcurrentifix
+        Hrm += 1
+        c0_offset += xifix^2 * Hx / 2
+      elseif Hi == newcurrentifix
+        Hrm += 1
+        c[Hj + shiftHj - 1] += xifix * Hx
+      elseif Hj == newcurrentifix
+        Hrm += 1
+        c[Hi + shiftHi - 1] += xifix * Hx
+      else
+        Hrows[Hwritepos] = (Hi < newcurrentifix) ? Hi : Hi - 1
+        Hcols[Hwritepos] = (Hj < newcurrentifix) ? Hj : Hj - 1
+        Hvals[Hwritepos] = Hx
+        Hwritepos += 1
+      end
+      k += 1
+    end
+
+    # remove ifix in A cols
+    Awritepos = 1
+    currentAn = nvar - idxfix + 1  # remove rows if uplo == :U 
+    k = 1
+    while k <= Annz && Acols[k] <= currentAn
+      Ai, Aj, Ax = Arows[k], Acols[k], Avals[k]
+      if Aj == newcurrentifix
+        Arm += 1
+        lcon[Ai] -= Ax * xifix
+        ucon[Ai] -= Ax * xifix
+      else
+        if Awritepos != k
+          Arows[Awritepos] = Ai
+          Acols[Awritepos] = (Aj < newcurrentifix) ? Aj : Aj - 1
+          Avals[Awritepos] = Ax
+        end
+        Awritepos += 1
+      end
+      k += 1
+    end
+
+    # update c0 with c[currentifix] coeff
+    c0_offset += c[currentifix] * xifix
+  end
+
+  # resize Q and A
+  if nfix > 0
+    Hnnz -= Hrm
+    Annz -= Arm
+    resize!(Hrows, Hnnz)
+    resize!(Hcols, Hnnz)
+    resize!(Hvals, Hnnz)
+    resize!(Arows, Annz)
+    resize!(Acols, Annz)
+    resize!(Avals, Annz)
+  end
+
+  # store removed x values
+  xrm = lvar[ifix]
+
+  # remove coefs in lvar, uvar, c
+  deleteat!(c, ifix)
+  deleteat!(lvar, ifix)
+  deleteat!(uvar, ifix)
+
+  # update c0
+  c0ps = c0 + c0_offset
+
+  nvarrm = nvar - nfix
+
+  return xrm, c0ps, nvarrm
+end
+
+function restore_ifix!(ifix, xrm, x, xout)
+  # put x and xrm inside xout
+  cfix, cx = 1, 1
+  nfix = length(ifix)
+  for i = 1:length(xout)
+    if cfix <= nfix && i == ifix[cfix]
+      xout[i] = xrm[cfix]
+      cfix += 1
+    else
+      xout[i] = x[cx]
+      cx += 1
+    end
+  end
+end

--- a/src/presolve/remove_ifix.jl
+++ b/src/presolve/remove_ifix.jl
@@ -1,5 +1,20 @@
 # ̃xᵀ̃Hx̃ + ̃ĉᵀx̃ + lⱼ²Hⱼⱼ + cⱼxⱼ + c₀
-# ̂c = ̃c + 2lⱼΣₖHⱼₖxₖ , k ≂̸ j  
+# ̂c = ̃c + 2lⱼΣₖHⱼₖxₖ , k ≂̸ j
+
+"""
+    xrm, c0ps, nvarrm = remove_ifix!(ifix, Hrows, Hcols, Hvals, nvar, 
+                                     Arows, Acols, Avals, c, c0, 
+                                     lvar, uvar, lcon, ucon)
+
+Remove rows and columns in H, columns in A, and elements in lcon and ucon
+corresponding to fixed variables, that are in `ifix`
+(They should be the indices `i` where `lvar[i] == uvar[i]`).
+
+Returns the removed elements of `lvar` (or `uvar`), the offset in the QP
+objective `c0ps`, and the new number of variables `nvarrm`.
+`Hrows`, `Hcols`, `Hvals`, `Arows`, `Acols`, `Avals`, `c`, `lvar`, `uvar`,
+`lcon` and `ucon` are updated in-place.
+"""
 function remove_ifix!(
   ifix,
   Hrows,
@@ -30,10 +45,13 @@ function remove_ifix!(
   for idxfix = 1:nfix
     currentifix = ifix[idxfix]
     xifix = lvar[currentifix]
+    # value of the current fixed variable that takes the number of 
+    # already removed variables into account:
     newcurrentifix = currentifix - idxfix + 1
 
     Hwritepos = 1
-    shiftHj = 1 # increase Hj of currentj - 1 if Hj
+    # shift corresponding to the already removed fixed variables to update c:
+    shiftHj = 1 
     if Hnnz > 0
       oldHj = Hrows[1]
     end
@@ -58,7 +76,7 @@ function remove_ifix!(
       elseif Hj == newcurrentifix
         Hrm += 1
         c[Hi + shiftHi - 1] += xifix * Hx
-      else
+      else # keep Hi, Hj, Hx
         Hrows[Hwritepos] = (Hi < newcurrentifix) ? Hi : Hi - 1
         Hcols[Hwritepos] = (Hj < newcurrentifix) ? Hj : Hj - 1
         Hvals[Hwritepos] = Hx

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -71,3 +71,5 @@ end
   SlackModel!(qp)
   testSM(qp)
 end
+
+include("test_presolve.jl")

--- a/test/test_presolve.jl
+++ b/test/test_presolve.jl
@@ -27,7 +27,9 @@
     
   psqp = presolve(qp)
 
-  Hps_true =   H = [
+  c_true = [-4.0; 1.0]
+  c0_true = 4.0
+  Hps_true = [
     6.0 1.0
     1.0 4.0
   ]
@@ -35,18 +37,22 @@
     1.0 1.0
     0.0 1.0
   ]
-
   lvarps_true, uvarps_true = [0. ; 0.], [Inf; Inf]
-  @test psqp.meta.lvar == lvarps_true
-  @test psqp.meta.uvar == uvarps_true
-  println(psqp.data.c)
-  println(psqp.data.c0)
-  Aps = sparse(psqp.data.Arows, psqp.data.Acols, psqp.data.Avals, psqp.meta.ncon, psqp.meta.nvar)
-  @test norm(Aps - sparse(Aps_true)) ≤ sqrt(eps(T))
+
+  @test psqp.data.c == [-4.0; 1.0]
+  @test psqp.data.c0 == 4.0
   Hps = sparse(psqp.data.Hrows, psqp.data.Hcols, psqp.data.Hvals, psqp.meta.ncon, psqp.meta.nvar)
   @test norm(Symmetric(Hps, :L) - sparse(Hps_true)) ≤ sqrt(eps(T))
+  Aps = sparse(psqp.data.Arows, psqp.data.Acols, psqp.data.Avals, psqp.meta.ncon, psqp.meta.nvar)
+  @test norm(Aps - sparse(Aps_true)) ≤ sqrt(eps(T))
+  @test psqp.meta.lvar == lvarps_true
+  @test psqp.meta.uvar == uvarps_true
   @test psqp.xrm == [2.0]
   @test psqp.meta.ifix == Int[]
   @test psqp.meta.nvar == 2
 
+  x_in = [4.0; 7.0]
+  x_out = zeros(3)
+  postsolve!(qp, psqp, x_in, x_out)
+  @test x_out == [4.0; 2.0; 7.0]
 end

--- a/test/test_presolve.jl
+++ b/test/test_presolve.jl
@@ -1,0 +1,52 @@
+@testset "presolve ifix" begin
+  H = [
+    6.0 2.0 1.0
+    2.0 5.0 2.0
+    1.0 2.0 4.0
+  ]
+  c = [-8.0; -3; -3]
+  A = [
+    1.0 0.0 1.0
+    0.0 2.0 1.0
+  ]
+  b = [0.0; 3]
+  l = [0.0; 2.0; 0]
+  u = [Inf; 2.0; Inf]
+  T = eltype(c)
+  qp = QuadraticModel(
+    c,
+    H,
+    A = A,
+    lcon = [-3.0; -4.0],
+    ucon = [-2.0; Inf],
+    lvar = l,
+    uvar = u,
+    c0 = 0.0,
+    name = "QM1",
+  )
+    
+  psqp = presolve(qp)
+
+  Hps_true =   H = [
+    6.0 1.0
+    1.0 4.0
+  ]
+  Aps_true = [
+    1.0 1.0
+    0.0 1.0
+  ]
+
+  lvarps_true, uvarps_true = [0. ; 0.], [Inf; Inf]
+  @test psqp.meta.lvar == lvarps_true
+  @test psqp.meta.uvar == uvarps_true
+  println(psqp.data.c)
+  println(psqp.data.c0)
+  Aps = sparse(psqp.data.Arows, psqp.data.Acols, psqp.data.Avals, psqp.meta.ncon, psqp.meta.nvar)
+  @test norm(Aps - sparse(Aps_true)) ≤ sqrt(eps(T))
+  Hps = sparse(psqp.data.Hrows, psqp.data.Hcols, psqp.data.Hvals, psqp.meta.ncon, psqp.meta.nvar)
+  @test norm(Symmetric(Hps, :L) - sparse(Hps_true)) ≤ sqrt(eps(T))
+  @test psqp.xrm == [2.0]
+  @test psqp.meta.ifix == Int[]
+  @test psqp.meta.nvar == 2
+
+end


### PR DESCRIPTION
@dpo I will do this step by step. For now this only removes fixed variables.

I chose to create a new type of `AbstractQuadraticModel` after the presolve. The usage is similar to `SlackModel`:

```julia
qpps = presolve(qp)
```
[algorithm...]
```julia
postsolve!(qp, qpps, x_in, x_out)
```