### PR TITLE
QPDataDense

### DIFF
--- a/src/QuadraticModels.jl
+++ b/src/QuadraticModels.jl
@@ -31,6 +31,7 @@ import NLPModels:
 
 export AbstractQuadraticModel, QuadraticModel, presolve, postsolve!
 
+include("linalg_utils.jl")
 include("qpmodel.jl")
 include("presolve/presolve.jl")
 

--- a/src/linalg_utils.jl
+++ b/src/linalg_utils.jl
@@ -1,0 +1,9 @@
+import SparseArrays.nnz
+
+SparseArrays.nnz(M::DenseMatrix) = *(size(M)...)
+SparseArrays.nnz(M::Diagonal{T, <: DenseVector{T}}) where T = size(M, 1)
+SparseArrays.nnz(M::SymTridiagonal{T, <: DenseVector{T}}) where T = 2 * size(M, 1) - 1
+function SparseArrays.nnz(M::Symmetric{T, <: DenseMatrix{T}}) where T
+  n = size(M, 1)
+  return n * (n + 1) / 2
+end

--- a/src/presolve/presolve.jl
+++ b/src/presolve/presolve.jl
@@ -1,6 +1,6 @@
 include("remove_ifix.jl")
 
-mutable struct PresolvedQuadraticModel{T, S, D <: AbstractQPData} <: AbstractQuadraticModel{T, S}
+mutable struct PresolvedQuadraticModel{T, S, D <: AbstractQPData{T, S}} <: AbstractQuadraticModel{T, S}
   meta::NLPModelMeta{T, S}
   counters::Counters
   data::D

--- a/src/presolve/presolve.jl
+++ b/src/presolve/presolve.jl
@@ -1,9 +1,9 @@
 include("remove_ifix.jl")
 
-mutable struct PresolvedQuadraticModel{T, S} <: AbstractQuadraticModel{T, S}
+mutable struct PresolvedQuadraticModel{T, S, D <: AbstractQPData} <: AbstractQuadraticModel{T, S}
   meta::NLPModelMeta{T, S}
   counters::Counters
-  data::QPData{T, S}
+  data::D
   xrm::S
 end
 

--- a/src/qpmodel.jl
+++ b/src/qpmodel.jl
@@ -154,8 +154,6 @@ function QuadraticModel(
   )
 end
 
-QuadraticModel(c::S, H::AbstractMatrix; args...) where {S} = QuadraticModel(c, sparse(H); args...)
-
 """
     QuadraticModel(nlp, x)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -56,7 +56,7 @@ end
   T = eltype(c)
   qp = QuadraticModel(
     c,
-    H,
+    sparse(H),
     A = A,
     lcon = [-3.0; -4.0],
     ucon = [-2.0; Inf],

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -70,6 +70,20 @@ end
 
   SlackModel!(qp)
   testSM(qp)
+
+  qpdense = QuadraticModel(
+    c,
+    H,
+    A = A,
+    lcon = [-3.0; -4.0],
+    ucon = [-2.0; Inf],
+    lvar = l,
+    uvar = u,
+    c0 = 0.0,
+    name = "QM1",
+  )
+  smdense = SlackModel(qpdense)
+  testSM(smdense)
 end
 
 @testset "sort cols COO" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,15 @@ using LinearAlgebra, Printf, SparseArrays, Test
 using ADNLPModels,
   LinearOperators, NLPModels, NLPModelsModifiers, NLPModelsTest, QPSReader, QuadraticModels
 
+@testset "test utils" begin
+  A = rand(10, 10)
+  @test nnz(A) == 100
+  @test nnz(Diagonal(A)) == 10
+  @test nnz(Symmetric(A)) == 55
+  v1, v2 = rand(10), rand(9)
+  @test nnz(SymTridiagonal(v1, v2)) == 19
+end
+
 # Definition of quadratic problems
 qp_problems_Matrix = ["bndqp", "eqconqp"]
 qp_problems_COO = ["uncqp", "ineqconqp"]

--- a/test/test_presolve.jl
+++ b/test/test_presolve.jl
@@ -15,7 +15,7 @@
   T = eltype(c)
   qp = QuadraticModel(
     c,
-    H,
+    sparse(H),
     A = A,
     lcon = [-3.0; -4.0],
     ucon = [-2.0; Inf],


### PR DESCRIPTION
This PR allows the use to create QuadraticModels with dense `H` and `A`.
A few notes:

- in the `QPDataDense` struct, `M1 != M2` so that the user can provide special matrices such as `Diagonal` matrices,
- NLPModel's function`hess_structure!` and `hess_coord!` generate COO coefficients for a full matrix with zeros in the upper triangle in order to pass the tests in NLPModelsTest,
- I did not implement specialized functions for `QPDataDense` when using `SlackModel` because it is supposed to create many zeros, so using `SlackModel` on this type of QPData converts it to  a `QPDataCOO`,
- I did not implement specialized functions for `QPDataDense` when using `presolve`, I suggest this is done in a separate PR (I can open an issue)