### PR TITLE
Realease 0.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuadraticModels"
 uuid = "f468eda6-eac5-11e8-05a5-ff9e497bcd19"
 authors = ["Dominique Orban <dominique.orban@gmail.com>"]
-version = "0.6.0"
+version = "0.7.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
https://github.com/JuliaSmoothOptimizers/QuadraticModels.jl/pull/58 changed the acces of `qp.data.Arows` etc to `qp.data.A.rows` for sparseCOO matrices