### PR TITLE
Default input type to SparseMatricesCOO

### DIFF
--- a/src/QuadraticModels.jl
+++ b/src/QuadraticModels.jl
@@ -28,6 +28,8 @@ import NLPModels:
   jtprod
 import NLPModelsModifiers: SlackModel, slack_meta
 
+import Base.convert
+
 export AbstractQuadraticModel, QuadraticModel, presolve, postsolve!
 
 include("linalg_utils.jl")

--- a/src/linalg_utils.jl
+++ b/src/linalg_utils.jl
@@ -7,3 +7,4 @@ function SparseArrays.nnz(M::Symmetric{T, <:DenseMatrix{T}}) where {T}
   n = size(M, 1)
   return n * (n + 1) / 2
 end
+SparseArrays.nnz(M::Symmetric{T, <:AbstractSparseMatrix{T}}) where {T} = nnz(M.data)

--- a/src/qpmodel.jl
+++ b/src/qpmodel.jl
@@ -398,7 +398,7 @@ function NLPModels.jac_coord!(
   vals::AbstractVector
   ) where {T, S, M1, M2 <: SparseMatrixCSC}
   NLPModels.increment!(qp, :neval_jac)
-  fill_coord!(qp.data.H, vals, one(T))
+  fill_coord!(qp.data.A, vals, one(T))
   return vals
 end
 

--- a/src/qpmodel.jl
+++ b/src/qpmodel.jl
@@ -27,7 +27,7 @@ abstract type AbstractQuadraticModel{T, S} <: AbstractNLPModel{T, S} end
     qp = QuadraticModel(c, Hrows, Hcols, Hvals; Arows = Arows, Acols = Acols, Avals = Avals, 
                         lcon = lcon, ucon = ucon, lvar = lvar, uvar = uvar, sortcols = false)
 
-    qp = QuadraticModel(c, H; A = A, lcon = lcon, ucon = ucon, lvar = lvar, uvar = uvar, coo_matrices = true)
+    qp = QuadraticModel(c, H; A = A, lcon = lcon, ucon = ucon, lvar = lvar, uvar = uvar)
 
 Create a Quadratic model ``min ~\\tfrac{1}{2} x^T H x + c^T x + c_0`` with optional bounds
 `lvar ≦ x ≦ uvar` and optional linear constraints `lcon ≦ Ax ≦ ucon`.
@@ -370,7 +370,7 @@ function NLPModels.jac_structure!(
   qp::QuadraticModel{T, S, M1, M2},
   rows::AbstractVector{<:Integer},
   cols::AbstractVector{<:Integer},
-) where {T, S, M1, M2 <: DenseMatrix}
+) where {T, S, M1, M2 <: Matrix}
   count = 1
   for j=1:qp.meta.nvar
     for i=1:qp.meta.ncon
@@ -406,7 +406,7 @@ function NLPModels.jac_coord!(
   qp::QuadraticModel{T, S, M1, M2},
   x::AbstractVector,
   vals::AbstractVector
-  ) where {T, S, M1, M2 <: DenseMatrix}
+  ) where {T, S, M1, M2 <: Matrix}
   NLPModels.increment!(qp, :neval_jac)
   count = 1
   for j=1:qp.meta.nvar

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using LinearAlgebra, Printf, SparseArrays, Test
 
 # our packages
 using ADNLPModels,
-  LinearOperators, NLPModels, NLPModelsModifiers, NLPModelsTest, QPSReader, QuadraticModels
+  LinearOperators, NLPModels, NLPModelsModifiers, NLPModelsTest, QPSReader, QuadraticModels, SparseMatricesCOO
 
 @testset "test utils" begin
   A = rand(10, 10)
@@ -12,6 +12,8 @@ using ADNLPModels,
   @test nnz(Symmetric(A)) == 55
   v1, v2 = rand(10), rand(9)
   @test nnz(SymTridiagonal(v1, v2)) == 19
+  Asp = sparse([1. 0. 0. ; 1. 0. 0. ; 0. 3. 2.])
+  @test nnz(Symmetric(Asp, :L)) == 4
 end
 
 # Definition of quadratic problems
@@ -161,7 +163,7 @@ end
   ucon = lcon .+ 100.0
   qp = QuadraticModel(
     c,
-    H,
+    SparseMatrixCOO(H.data),
     A = A,
     lcon = lcon,
     ucon = ucon,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -205,4 +205,46 @@ end
   @test objgrad(SMLO, x)[2] ≈ objgrad(SM, x)[2]
 end
 
+@testset "struct and coord CSC" begin
+  H = [
+    6.0 2.0 1.0
+    2.0 5.0 2.0
+    1.0 2.0 4.0
+  ]
+  c = [-8.0; -3; -3]
+  A = [
+    1.0 0.0 1.0
+    0.0 2.0 1.0
+  ]
+  b = [0.0; 3]
+  l = [0.0; 0; 0]
+  u = [Inf; Inf; Inf]
+  T = eltype(c)
+  qp = QuadraticModel(
+    c,
+    tril(sparse(H)),
+    A = sparse(A),
+    lcon = b,
+    ucon = b,
+    lvar = l,
+    uvar = u,
+    c0 = 0.0,
+    name = "QM",
+  )
+
+  x = zeros(3)
+  rowsH, colsH = hess_structure(qp)
+  valsH = hess_coord(qp, x)
+  rowsHtrue, colsHtrue, valsHtrue = findnz(tril(sparse(H)))
+  @test rowsH == rowsHtrue
+  @test colsH == colsHtrue
+  @test valsH == valsHtrue
+  rowsA, colsA = jac_structure(qp)
+  valsA = jac_coord(qp, x)
+  rowsAtrue, colsAtrue, valsAtrue = findnz(sparse(A))
+  @test rowsA == rowsAtrue
+  @test colsA == colsAtrue
+  @test valsA == valsAtrue
+end
+
 include("test_presolve.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -170,11 +170,12 @@ end
   y = rand(SM.meta.ncon)
   @test SM.meta.nvar == qp.meta.nvar + ns
   @test obj(SM, x) == obj(SMLO, x)
-  @test grad(SM, x) == grad(SMLO, x)
+  @test grad(SM, x) ≈ grad(SMLO, x)
   @test cons(SM, x) == cons(SMLO, x)
   @test hprod(SMLO, x, x) == hprod(SMLO, x, x)
   @test jtprod(SMLO, x, y) == jtprod(SM, x, y)
-  @test objgrad(SMLO, x) == objgrad(SM, x)
+  @test objgrad(SMLO, x)[1] ≈ objgrad(SM, x)[1]
+  @test objgrad(SMLO, x)[2] ≈ objgrad(SM, x)[2]
 end
 
 include("test_presolve.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -128,7 +128,7 @@ end
 @testset "LinearOperators" begin
   nvar, ncon = 10, 7
   T = Float64
-  H = Symmetric(tril!(sprand(T, nvar, nvar, 0.3)))
+  H = Symmetric(tril!(sprand(T, nvar, nvar, 0.3)), :L)
   A = sprand(T, ncon, nvar, 0.4)
   c = rand(nvar)
   lvar = fill(-Inf, nvar)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -111,12 +111,7 @@ end
     name = "QM1",
     coo_matrices = false,
   )
-
-  @test_throws Exception hess_structure(qpdense)
-  @test_throws Exception hess_coord(qpdense)
-  @test_throws Exception jac_structure(qpdense)
-  @test_throws Exception jac_coord(qpdense)
-
+  
   smdense = SlackModel(qpdense)
   testSM(smdense)
 end

--- a/test/test_presolve.jl
+++ b/test/test_presolve.jl
@@ -15,8 +15,8 @@
   T = eltype(c)
   qp = QuadraticModel(
     c,
-    sparse(H),
-    A = A,
+    SparseMatrixCOO(tril(H)),
+    A = SparseMatrixCOO(A),
     lcon = [-3.0; -4.0],
     ucon = [-2.0; Inf],
     lvar = l,


### PR DESCRIPTION
I chose the default input type to be `SparseMatricesCOO`, since NLPModels work in COO format.
This is clearer for the user now because if he wants to use other input types for `H` and `A` he will have to specify it, but some functions will not be usable, such as `hess_structure!`