### PR TITLE
Version 0.8.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuadraticModels"
 uuid = "f468eda6-eac5-11e8-05a5-ff9e497bcd19"
 authors = ["Dominique Orban <dominique.orban@gmail.com>"]
-version = "0.8.1"
+version = "0.8.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuadraticModels"
 uuid = "f468eda6-eac5-11e8-05a5-ff9e497bcd19"
 authors = ["Dominique Orban <dominique.orban@gmail.com>"]
-version = "0.8.2"
+version = "0.9.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
Since the `0.8` is very recent, I suggest the update to NLPModels 0.18-0.19 (dropping 0.17) remains in the 0.8.