### PR TITLE
Reinstate 5-arg constructor for `QPData`

### DIFF
--- a/src/qpmodel.jl
+++ b/src/qpmodel.jl
@@ -19,6 +19,8 @@ end
 
 @inline QPData(c0, c, H, A; regularize = false, selected = 1:length(c), σ = zero(c0)) =
   QPData(c0, c, similar(c), H, A, regularize, selected, σ)
+@inline QPData(c0, c, v, H, A; regularize = false, selected = 1:length(c), σ = zero(c0)) =
+  QPData(c0, c, v, H, A, regularize, selected, σ)
 isdense(data::QPData{T, S, M1, M2}) where {T, S, M1, M2} = M1 <: DenseMatrix || M2 <: DenseMatrix
 
 function Base.convert(


### PR DESCRIPTION
I believe this can be considered a bug fix since before https://github.com/JuliaSmoothOptimizers/QuadraticModels.jl/pull/166, building a `QPData` with `QPData(c0, c, v, H, A)` worked, and now it doesn't since some fields were added to the struct. I think it's nicer to reinstate this constructor here in QM rather than adjusting all callers (e.g. in MadIPM) to include `; regularize = false, selected = 1:length(c), σ = zero(c0)`, but open for discussion.